### PR TITLE
Remove unused Example component from projects.tsx

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -101,9 +101,9 @@ export const R2_BUCKET = process.env.NEXT_PUBLIC_R2_BUCKET || '';
 **Issue**: Unused `Example` component
 
 **Action**:
-- [ ] Remove the unused Example component
-- [ ] Run build to ensure nothing breaks
-- [ ] Search for other unused components/functions
+- [x] Remove the unused Example component
+- [x] Run build to ensure nothing breaks
+- [x] Search for other unused components/functions
 
 ---
 

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -13,43 +13,6 @@ import {
 } from "@headlessui/react";
 import { useState } from "react";
 
-function Example() {
-  let [isOpen, setIsOpen] = useState(false);
-
-  return (
-    <>
-      <button onClick={() => setIsOpen(true)}>Open dialog</button>
-      <Dialog
-        open={isOpen}
-        onClose={() => setIsOpen(false)}
-        className="relative z-50"
-      >
-        {/* The backdrop, rendered as a fixed sibling to the panel container */}
-        <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
-
-        {/* Full-screen container to center the panel */}
-        <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
-          {/* The actual dialog panel  */}
-          <DialogPanel className="max-w-lg space-y-4 bg-white p-12">
-            <DialogTitle className="font-bold">Deactivate account</DialogTitle>
-            <Description>
-              This will permanently deactivate your account
-            </Description>
-            <p>
-              Are you sure you want to deactivate your account? All of your data
-              will be permanently removed.
-            </p>
-            <div className="flex gap-4">
-              <button onClick={() => setIsOpen(false)}>Cancel</button>
-              <button onClick={() => setIsOpen(false)}>Deactivate</button>
-            </div>
-          </DialogPanel>
-        </div>
-      </Dialog>
-    </>
-  );
-}
-
 type Project = {
   title: string;
   description: string;


### PR DESCRIPTION
- Removed the unused Example dialog component (36 lines)
- Searched codebase for other unused components
- Marked all action items for point 4 as completed in IMPROVEMENTS.md